### PR TITLE
Fixes from Blowerlop plus [ClearOnReload] works with events and properties.

### DIFF
--- a/Editor/DomainReloadHandler.cs
+++ b/Editor/DomainReloadHandler.cs
@@ -34,7 +34,7 @@ public class DomainReloadHandler
                 if (valueToAssign != null) {
                     value = Convert.ChangeType(valueToAssign, fieldType);
                     if (value == null)
-                        Debug.LogWarning("Unable to assign value of type {valueToAssign.GetType()} to field {field.Name} of type {fieldType}.");
+                        Debug.LogWarning($"Unable to assign value of type {valueToAssign.GetType()} to field {field.Name} of type {fieldType}.");
                 }
 
                 // If assignNewTypeInstance is set, create a new instance of this type and assign it to the field
@@ -47,13 +47,13 @@ public class DomainReloadHandler
                 }
                 catch {
                     if (valueToAssign == null)
-                        Debug.LogWarning("Unable to clear field {field.Name}.");
+                        Debug.LogWarning($"Unable to clear field {field.Name}.");
                     else
-                        Debug.LogWarning("Unable to assign field {field.Name}.");
+                        Debug.LogWarning($"Unable to assign field {field.Name}.");
                 }
 
             } else {
-                Debug.LogWarning("Inapplicable field {field.Name} to clear; must be static and non-generic.");
+                Debug.LogWarning($"Inapplicable field {field.Name} to clear; must be static and non-generic.");
             }
 
         }

--- a/Editor/DomainReloadHandler.cs
+++ b/Editor/DomainReloadHandler.cs
@@ -38,8 +38,9 @@ public class DomainReloadHandler
                 }
 
                 // If assignNewTypeInstance is set, create a new instance of this type and assign it to the field
-                if (assignNewTypeInstance)
-                    value = Activator.CreateInstance(fieldType);
+                if (assignNewTypeInstance){
+                    value = Activator.CreateInstance(fieldType, reloadAttribute.arguments);
+                }
 
                 try {
                     field.SetValue(null, value);

--- a/Runtime/DomainReloadAttributes.cs
+++ b/Runtime/DomainReloadAttributes.cs
@@ -1,6 +1,6 @@
 using System;
 
-[AttributeUsage(AttributeTargets.Field)]
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
 public class ClearOnReloadAttribute : Attribute
 {
     public readonly object valueToAssign;

--- a/Runtime/DomainReloadAttributes.cs
+++ b/Runtime/DomainReloadAttributes.cs
@@ -1,6 +1,6 @@
 using System;
 
-[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Event)]
 public class ClearOnReloadAttribute : Attribute
 {
     public readonly object valueToAssign;

--- a/Runtime/DomainReloadAttributes.cs
+++ b/Runtime/DomainReloadAttributes.cs
@@ -30,7 +30,7 @@ public class ClearOnReloadAttribute : Attribute
     ///     Marks field of property to be cleared or re-initialized on reload.
     /// </summary>
     /// <param name="assignNewTypeInstance">If true, field/property will be assigned a newly created object of its type on reload. Has no effect on events.</param>
-    public ClearOnReloadAttribute(bool assignNewTypeInstance = false, object[] arguments = null)
+    public ClearOnReloadAttribute(bool assignNewTypeInstance = false, params object[] arguments = null)
     {
         this.valueToAssign = null;
         this.assignNewTypeInstance = assignNewTypeInstance;

--- a/Runtime/DomainReloadAttributes.cs
+++ b/Runtime/DomainReloadAttributes.cs
@@ -30,7 +30,7 @@ public class ClearOnReloadAttribute : Attribute
     ///     Marks field of property to be cleared or re-initialized on reload.
     /// </summary>
     /// <param name="assignNewTypeInstance">If true, field/property will be assigned a newly created object of its type on reload. Has no effect on events.</param>
-    public ClearOnReloadAttribute(bool assignNewTypeInstance = false, params object[] arguments = null)
+    public ClearOnReloadAttribute(bool assignNewTypeInstance = false, params object[] arguments)
     {
         this.valueToAssign = null;
         this.assignNewTypeInstance = assignNewTypeInstance;

--- a/Runtime/DomainReloadAttributes.cs
+++ b/Runtime/DomainReloadAttributes.cs
@@ -5,6 +5,7 @@ public class ClearOnReloadAttribute : Attribute
 {
     public readonly object valueToAssign;
     public readonly bool assignNewTypeInstance;
+    public readonly object[] arguments;
 
     /// <summary>
     ///     Marks field, property or event to be cleared on reload.
@@ -29,10 +30,11 @@ public class ClearOnReloadAttribute : Attribute
     ///     Marks field of property to be cleared or re-initialized on reload.
     /// </summary>
     /// <param name="assignNewTypeInstance">If true, field/property will be assigned a newly created object of its type on reload. Has no effect on events.</param>
-    public ClearOnReloadAttribute(bool assignNewTypeInstance = false)
+    public ClearOnReloadAttribute(bool assignNewTypeInstance = false, object[] arguments = null)
     {
         this.valueToAssign = null;
         this.assignNewTypeInstance = assignNewTypeInstance;
+        this.arguments = arguments;
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.jsteinhauer.unitydomainreloadhelper",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "displayName": "Unity Domain Reload Helper",
   "description": "A couple of attributes that help disabling Domain Reloading in Unity easier.",
   "unity": "2019.3",


### PR DESCRIPTION
Includes improvements from [Blowerlop](https://github.com/joshcamas/unity-domain-reload-helper/commits?author=Blowerlop) as well as support for [ClearOnReload] with static events and properties.

For example:
```
[ClearOnReload] public static event OnButtonClick;
[ClearOnReload] public static float timer { get; private set; }
```
Changed package version to 1.0.2