### PR TITLE
Add support for constructors requiring parameters

### DIFF
--- a/Editor/DomainReloadHandler.cs
+++ b/Editor/DomainReloadHandler.cs
@@ -34,12 +34,13 @@ public class DomainReloadHandler
                 if (valueToAssign != null) {
                     value = Convert.ChangeType(valueToAssign, fieldType);
                     if (value == null)
-                        Debug.LogWarning("Unable to assign value of type {valueToAssign.GetType()} to field {field.Name} of type {fieldType}.");
+                        Debug.LogWarning($"Unable to assign value of type {valueToAssign.GetType()} to field {field.Name} of type {fieldType}.");
                 }
 
                 // If assignNewTypeInstance is set, create a new instance of this type and assign it to the field
-                if (assignNewTypeInstance)
-                    value = Activator.CreateInstance(fieldType);
+                if (assignNewTypeInstance){
+                    value = Activator.CreateInstance(fieldType, reloadAttribute.arguments);
+                }
 
                 try {
                     field.SetValue(null, value);
@@ -47,13 +48,13 @@ public class DomainReloadHandler
                 }
                 catch {
                     if (valueToAssign == null)
-                        Debug.LogWarning("Unable to clear field {field.Name}.");
+                        Debug.LogWarning($"Unable to clear field {field.Name}.");
                     else
-                        Debug.LogWarning("Unable to assign field {field.Name}.");
+                        Debug.LogWarning($"Unable to assign field {field.Name}.");
                 }
 
             } else {
-                Debug.LogWarning("Inapplicable field {field.Name} to clear; must be static and non-generic.");
+                Debug.LogWarning($"Inapplicable field {field.Name} to clear; must be static and non-generic.");
             }
 
         }

--- a/Runtime/DomainReloadAttributes.cs
+++ b/Runtime/DomainReloadAttributes.cs
@@ -5,6 +5,7 @@ public class ClearOnReloadAttribute : Attribute
 {
     public readonly object valueToAssign;
     public readonly bool assignNewTypeInstance;
+    public readonly object[] arguments;
 
     /// <summary>
     ///     Marks field, property or event to be cleared on reload.
@@ -29,10 +30,11 @@ public class ClearOnReloadAttribute : Attribute
     ///     Marks field of property to be cleared or re-initialized on reload.
     /// </summary>
     /// <param name="assignNewTypeInstance">If true, field/property will be assigned a newly created object of its type on reload. Has no effect on events.</param>
-    public ClearOnReloadAttribute(bool assignNewTypeInstance = false)
+    public ClearOnReloadAttribute(bool assignNewTypeInstance = false, params object[] arguments)
     {
         this.valueToAssign = null;
         this.assignNewTypeInstance = assignNewTypeInstance;
+        this.arguments = arguments;
     }
 }
 

--- a/Runtime/DomainReloadAttributes.cs
+++ b/Runtime/DomainReloadAttributes.cs
@@ -30,6 +30,7 @@ public class ClearOnReloadAttribute : Attribute
     ///     Marks field of property to be cleared or re-initialized on reload.
     /// </summary>
     /// <param name="assignNewTypeInstance">If true, field/property will be assigned a newly created object of its type on reload. Has no effect on events.</param>
+    /// <param name="arguments">Pass arguments to the constructor of the new type instance.</param>
     public ClearOnReloadAttribute(bool assignNewTypeInstance = false, params object[] arguments)
     {
         this.valueToAssign = null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.jsteinhauer.unitydomainreloadhelper",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "displayName": "Unity Domain Reload Helper",
   "description": "A couple of attributes that help disabling Domain Reloading in Unity easier.",
   "unity": "2019.3",


### PR DESCRIPTION
Hi Josh,

I've added the ability to create a new type instance for constructors requiring parameters. This is particularly useful when the type doesn't have a constructor without parameters. 